### PR TITLE
fix exception handling for builds without exception support

### DIFF
--- a/ANIMartRIX.h
+++ b/ANIMartRIX.h
@@ -56,8 +56,10 @@ public:
   PSRAMAllocator(const PSRAMAllocator<U>&) noexcept {}
 
   T* allocate(std::size_t n) {
+    #if __cpp_exceptions
     if (n > std::numeric_limits<std::size_t>::max() / sizeof(T)) throw std::bad_alloc();
-
+	#endif
+	  
     // Use heap_caps_malloc_prefer to try PSRAM first, then fall back to internal RAM.
     // The second argument '2' is the number of capability options to try.
     // update: IRAM option disabled - apparently we cannot store float in IRAM (LoadStoreError)
@@ -67,15 +69,18 @@ public:
 
     T* p;
     p = (T*) heap_caps_calloc_prefer(n, sizeof(T), 2, MALLOC_CAP_SPIRAM, MALLOC_CAP_DEFAULT);
-    if (!p) throw std::bad_alloc();
+    #if __cpp_exceptions
+	if (!p) throw std::bad_alloc();
+	#endif
     return p;
   }
 
   // re-allocator - same logic as allocate(), but uses heap_caps_realloc_prefer to resize
   // Seems that std::vector won't call this, but the function is left here for custom use - for example with ArduinoJSON
   T* reallocate(T* p, std::size_t n) {
+    #if __cpp_exceptions
     if (n > std::numeric_limits<std::size_t>::max() / sizeof(T)) throw std::bad_alloc();
-
+    #endif
     // IRAM option disabled until the risk of "LoadStoreError" is clarified - see allocate()
 
     T* res;

--- a/ANIMartRIX.h
+++ b/ANIMartRIX.h
@@ -59,7 +59,6 @@ public:
     #if __cpp_exceptions
     if (n > std::numeric_limits<std::size_t>::max() / sizeof(T)) throw std::bad_alloc();
 	#endif
-	  
     // Use heap_caps_malloc_prefer to try PSRAM first, then fall back to internal RAM.
     // The second argument '2' is the number of capability options to try.
     // update: IRAM option disabled - apparently we cannot store float in IRAM (LoadStoreError)

--- a/ANIMartRIX.h
+++ b/ANIMartRIX.h
@@ -85,7 +85,9 @@ public:
 
     T* res;
     res = (T*) heap_caps_realloc_prefer(p, n * sizeof(T), 2, MALLOC_CAP_SPIRAM, MALLOC_CAP_DEFAULT);
+    #if __cpp_exceptions
     if (!res) throw std::bad_alloc();
+    #endif
     return res;
   }
 


### PR DESCRIPTION
some WLED-MM builds failed because "throw" cannot be used when exceptions are disabled (especially tasmota framework). This fix makes sure that "throw" is not used when the compiler has exceptions disabled.

https://github.com/MoonModules/WLED-MM/actions/runs/21217405554/job/61042395595#step:7:435
````
.pio/libdeps/esp32s2_PSRAM_M/animartrix/ANIMartRIX.h:425:60:   required from here
.pio/libdeps/esp32s2_PSRAM_M/animartrix/ANIMartRIX.h:59:87: error: exception handling disabled, use -fexceptions to enable
     if (n > std::numeric_limits<std::size_t>::max() / sizeof(T)) throw std::bad_alloc();
````